### PR TITLE
Use httpredir.debian.org as mirror

### DIFF
--- a/http/jessie-preseed.cfg
+++ b/http/jessie-preseed.cfg
@@ -15,7 +15,7 @@ d-i netcfg/wireless_wep string
 
 ### Mirror settings
 d-i mirror/country string manual
-d-i mirror/http/hostname string ftp.no.debian.org
+d-i mirror/http/hostname string httpredir.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 


### PR DESCRIPTION
Please consider using httpredir.debian.org as mirror, as this official Debian service will redirect APT to the closest and fastest debian mirror based on geographic and network location. This service will also redirect to another mirror if primary mirror is down.